### PR TITLE
Make template subject optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Thunderplates is a simple Thunderbird add-on for composing emails from reusable 
 
 ## Features
 
-- Define email templates in the add-on's settings page. Each template includes a name, subject and body text.
+- Define email templates in the add-on's settings page. Each template includes a name and body text, with an optional subject.
 - Insert a template from the compose window using the "Insert template" button.
-- Selecting a template replaces the subject and message body of the current draft.
+- Selecting a template replaces the message body and, if provided, the subject of the current draft.
 
 ## Installation
 

--- a/src/options.html
+++ b/src/options.html
@@ -16,7 +16,7 @@
   <h1>Templates</h1>
   <form id="addForm">
     <label>Template Name:<br/><input type="text" id="name" required/></label>
-    <label>Subject:<br/><input type="text" id="subject" required/></label>
+    <label>Subject:<br/><input type="text" id="subject"/></label>
     <label>Message:<br/><textarea id="body" required></textarea></label>
     <button type="submit">Add Template</button>
   </form>

--- a/src/options.js
+++ b/src/options.js
@@ -4,7 +4,7 @@ async function loadTemplates() {
   list.textContent = '';
   for (const [index, t] of templates.entries()) {
     const li = document.createElement('li');
-    li.textContent = `${t.name} - ${t.subject}`;
+    li.textContent = t.subject ? `${t.name} - ${t.subject}` : t.name;
     const del = document.createElement('button');
     del.textContent = 'Delete';
     del.className = 'delete';
@@ -23,7 +23,7 @@ document.getElementById('addForm').addEventListener('submit', async (e) => {
   const name = document.getElementById('name').value.trim();
   const subject = document.getElementById('subject').value.trim();
   const body = document.getElementById('body').value;
-  if (!name || !subject || !body) return;
+  if (!name || !body) return;
   const data = await browser.storage.local.get({ templates: [] });
   data.templates.push({ name, subject, body });
   await browser.storage.local.set(data);

--- a/src/popup.js
+++ b/src/popup.js
@@ -12,10 +12,11 @@ async function loadTemplates() {
     btn.addEventListener('click', async () => {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
       if (tab) {
-        await browser.compose.setComposeDetails(tab.id, {
-          subject: t.subject,
-          plainTextBody: t.body
-        });
+        const details = { plainTextBody: t.body };
+        if (t.subject) {
+          details.subject = t.subject;
+        }
+        await browser.compose.setComposeDetails(tab.id, details);
       }
       window.close();
     });


### PR DESCRIPTION
## Summary
- make the subject input optional in the options page
- handle templates that omit a subject in the options and popup scripts
- update docs for optional subjects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0eae0e988331a6c7c4c8da65fdda