### PR TITLE
Add HTML editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Thunderplates is a simple Thunderbird add-on for composing emails from reusable 
 
 ## Features
 
-- Define email templates in the add-on's settings page. Each template includes a name and body text, with an optional subject.
+- Define email templates in the add-on's settings page. Each template includes a name and HTML body text, with an optional subject. The body is edited using a simple WYSIWYG editor.
 - Insert a template from the compose window using the "Insert template" button.
 - Selecting a template replaces the message body and, if provided, the subject of the current draft.
 

--- a/src/options.html
+++ b/src/options.html
@@ -7,6 +7,7 @@
     body { font-family: sans-serif; padding: 1em; }
     label { display: block; margin-top: 0.5em; }
     textarea { width: 100%; height: 100px; }
+    #body { width: 100%; height: 100px; border: 1px solid #ccc; overflow: auto; padding: 0.5em; }
     ul { list-style: none; padding: 0; }
     li { margin: 0.5em 0; }
     button.delete { margin-left: 0.5em; }
@@ -18,7 +19,9 @@
     <input type="hidden" id="editIndex" value="" />
     <label>Template Name:<br/><input type="text" id="name" required/></label>
     <label>Subject:<br/><input type="text" id="subject"/></label>
-    <label>Message:<br/><textarea id="body" required></textarea></label>
+    <label>Message:<br/>
+      <div id="body" contenteditable="true"></div>
+    </label>
     <button type="submit" id="saveBtn">Add Template</button>
   </form>
 

--- a/src/options.js
+++ b/src/options.js
@@ -19,7 +19,7 @@ async function loadTemplates() {
     edit.addEventListener('click', () => {
       document.getElementById('name').value = t.name;
       document.getElementById('subject').value = t.subject;
-      document.getElementById('body').value = t.body;
+      document.getElementById('body').innerHTML = t.body;
       document.getElementById('editIndex').value = index;
       document.getElementById('saveBtn').textContent = 'Update Template';
     });
@@ -33,8 +33,8 @@ document.getElementById('templateForm').addEventListener('submit', async (e) => 
   e.preventDefault();
   const name = document.getElementById('name').value.trim();
   const subject = document.getElementById('subject').value.trim();
-  const body = document.getElementById('body').value;
-  if (!name || !body) return;
+  const body = document.getElementById('body').innerHTML;
+  if (!name || !body.trim()) return;
   const data = await browser.storage.local.get({ templates: [] });
   const editIndex = document.getElementById('editIndex').value;
   if (editIndex === '') {
@@ -44,6 +44,7 @@ document.getElementById('templateForm').addEventListener('submit', async (e) => 
   }
   await browser.storage.local.set(data);
   e.target.reset();
+  document.getElementById('body').innerHTML = '';
   document.getElementById('editIndex').value = '';
   document.getElementById('saveBtn').textContent = 'Add Template';
   loadTemplates();

--- a/src/popup.js
+++ b/src/popup.js
@@ -12,7 +12,7 @@ async function loadTemplates() {
     btn.addEventListener('click', async () => {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
       if (tab) {
-        const details = { plainTextBody: t.body };
+        const details = { body: t.body };
         if (t.subject) {
           details.subject = t.subject;
         }


### PR DESCRIPTION
## Summary
- store templates as HTML
- use a contenteditable div in Options for a simple WYSIWYG editor
- insert template body as HTML in compose window

## Testing
- `npm --version`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685f12ee9ce083318fc878c2faabc4bc