### PR TITLE
Add Quicktext import

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Thunderplates is a simple Thunderbird add-on for composing emails from reusable 
 - Define email templates in the add-on's settings page. Each template includes a name and HTML body text, with an optional subject. The body is edited using a simple WYSIWYG editor.
 - Insert a template from the compose window using the "Insert template" button.
 - Selecting a template replaces the message body and, if provided, the subject of the current draft.
+- Import templates from a Quicktext XML file on the options page.
 
 ## Installation
 

--- a/src/options.html
+++ b/src/options.html
@@ -28,6 +28,10 @@
   <h2>Existing Templates</h2>
   <ul id="templateList"></ul>
 
+  <h2>Import</h2>
+  <input type="file" id="quicktextFile" accept=".xml" />
+  <button id="importBtn">Import from Quicktext</button>
+
   <script src="options.js"></script>
 </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -51,3 +51,26 @@ document.getElementById('templateForm').addEventListener('submit', async (e) => 
 });
 
 loadTemplates();
+
+async function parseQuicktext(xml) {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  return Array.from(doc.querySelectorAll('text')).map((node) => {
+    const name = node.querySelector('name')?.textContent.trim() || 'Untitled';
+    const subject = node.querySelector('subject')?.textContent.trim() || '';
+    const body = node.querySelector('body')?.textContent || '';
+    return { name, subject, body };
+  });
+}
+
+document.getElementById('importBtn').addEventListener('click', async () => {
+  const file = document.getElementById('quicktextFile').files[0];
+  if (!file) return;
+  const xml = await file.text();
+  const imported = await parseQuicktext(xml);
+  if (imported.length === 0) return;
+  const data = await browser.storage.local.get({ templates: [] });
+  data.templates.push(...imported);
+  await browser.storage.local.set(data);
+  document.getElementById('quicktextFile').value = '';
+  loadTemplates();
+});


### PR DESCRIPTION
## Summary
- allow import from Quicktext XML on the options page
- document the new Quicktext import feature

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f173914008331b6a62621267f71b3