### PR TITLE
Align edit and delete buttons in template list

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -10,7 +10,7 @@
     #body { width: 100%; height: 100px; border: 1px solid #ccc; overflow: auto; padding: 0.5em; }
     ul { list-style: none; padding: 0; }
     li { margin: 0.5em 0; }
-    button.delete { margin-left: 0.5em; }
+    button.edit, button.delete { margin-right: 0.5em; }
   </style>
 </head>
 <body>

--- a/src/options.js
+++ b/src/options.js
@@ -4,15 +4,6 @@ async function loadTemplates() {
   list.textContent = '';
   for (const [index, t] of templates.entries()) {
     const li = document.createElement('li');
-    li.textContent = t.subject ? `${t.name} - ${t.subject}` : t.name;
-    const del = document.createElement('button');
-    del.textContent = 'Delete';
-    del.className = 'delete';
-    del.addEventListener('click', async () => {
-      templates.splice(index, 1);
-      await browser.storage.local.set({ templates });
-      loadTemplates();
-    });
     const edit = document.createElement('button');
     edit.textContent = 'Edit';
     edit.className = 'edit';
@@ -23,8 +14,19 @@ async function loadTemplates() {
       document.getElementById('editIndex').value = index;
       document.getElementById('saveBtn').textContent = 'Update Template';
     });
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.className = 'delete';
+    del.addEventListener('click', async () => {
+      templates.splice(index, 1);
+      await browser.storage.local.set({ templates });
+      loadTemplates();
+    });
+    const label = document.createElement('span');
+    label.textContent = t.subject ? `${t.name} - ${t.subject}` : t.name;
     li.appendChild(edit);
     li.appendChild(del);
+    li.appendChild(label);
     list.appendChild(li);
   }
 }


### PR DESCRIPTION
## Summary
- edit/delete buttons come first before template text
- adjust CSS margins to keep spacing consistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f18675f4883319b86ffb400c7eb5c