### PR TITLE
Add insertion at cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thunderplates is a simple Thunderbird add-on for composing emails from reusable 
 
 - Define email templates in the add-on's settings page. Each template includes a name and HTML body text, with an optional subject. The body is edited using a simple WYSIWYG editor.
 - Insert a template from the compose window using the "Insert template" button.
-- Selecting a template replaces the message body and, if provided, the subject of the current draft.
+- Selecting a template inserts its body at the current cursor position and, if provided, replaces the draft's subject.
 - Import templates from a Quicktext XML file on the options page.
 
 ## Installation

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,0 +1,14 @@
+browser.runtime.onMessage.addListener((message) => {
+  if (message.command === 'insertTemplate') {
+    const sel = document.getSelection();
+    if (!sel || sel.rangeCount === 0) {
+      return;
+    }
+    const range = sel.getRangeAt(0);
+    range.deleteContents();
+    const frag = range.createContextualFragment(message.html);
+    range.insertNode(frag);
+    // Move cursor to the end of the inserted content
+    sel.collapseToEnd();
+  }
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,11 @@
   "background": {
     "scripts": ["background.js"]
   },
+  "compose_scripts": [
+    {
+      "js": ["compose.js"]
+    }
+  ],
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true

--- a/src/popup.js
+++ b/src/popup.js
@@ -12,11 +12,17 @@ async function loadTemplates() {
     btn.addEventListener('click', async () => {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
       if (tab) {
-        const details = { body: t.body };
+        const details = {};
         if (t.subject) {
           details.subject = t.subject;
         }
-        await browser.compose.setComposeDetails(tab.id, details);
+        if (Object.keys(details).length > 0) {
+          await browser.compose.setComposeDetails(tab.id, details);
+        }
+        await browser.tabs.sendMessage(tab.id, {
+          command: 'insertTemplate',
+          html: t.body,
+        });
       }
       window.close();
     });


### PR DESCRIPTION
## Summary
- insert templates at the current cursor instead of replacing body
- load a compose script to handle the insertion
- update docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1aeb33488331a7feea2f06b2b958