### PR TITLE
Enable template insertion via context menu

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,49 @@
 // background.js
 
-browser.runtime.onInstalled.addListener(() => {
-  // Initialize storage with empty templates array if not present
-  browser.storage.local.get({ templates: [] }).then(() => {});
+async function buildMenus() {
+  await browser.menus.removeAll();
+  const { templates = [] } = await browser.storage.local.get('templates');
+  for (const [index, t] of templates.entries()) {
+    browser.menus.create({
+      id: `template-${index}`,
+      title: t.name,
+      contexts: ['editable'],
+    });
+  }
+  browser.menus.refresh();
+}
+
+browser.runtime.onInstalled.addListener(async () => {
+  await browser.storage.local.get({ templates: [] });
+  buildMenus();
 });
+
+browser.runtime.onStartup.addListener(buildMenus);
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.templates) {
+    buildMenus();
+  }
+});
+
+browser.menus.onClicked.addListener(async (info, tab) => {
+  if (!info.menuItemId.startsWith('template-')) return;
+  const index = parseInt(info.menuItemId.split('-')[1], 10);
+  const { templates = [] } = await browser.storage.local.get('templates');
+  const t = templates[index];
+  if (!t) return;
+  const details = {};
+  if (t.subject) {
+    details.subject = t.subject;
+  }
+  if (Object.keys(details).length > 0) {
+    await browser.compose.setComposeDetails(tab.id, details);
+  }
+  await browser.tabs.sendMessage(tab.id, {
+    command: 'insertTemplate',
+    html: t.body,
+  });
+});
+
+// Ensure menus are available when the background script first loads
+buildMenus();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,11 +9,12 @@
       "strict_min_version": "139.0"
     }
   },
-  "permissions": [
-    "compose",
-    "storage",
-    "tabs"
-  ],
+    "permissions": [
+      "compose",
+      "storage",
+      "tabs",
+      "menus"
+    ],
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
## Summary
- add `menus` permission to manifest
- build dynamic context menu items for templates
- handle context menu clicks to insert templates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1e33911883319b430fb942483360