### PR TITLE
Add context menu for template insertion

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,47 @@
 // background.js
 
-browser.runtime.onInstalled.addListener(() => {
+async function createContextMenus() {
+  await browser.menus.removeAll();
+  const { templates = [] } = await browser.storage.local.get('templates');
+  if (templates.length === 0) {
+    return;
+  }
+  const parentId = browser.menus.create({
+    id: 'thunderplates-parent',
+    title: 'Insert template',
+    contexts: ['editable'],
+  });
+  for (const [index, t] of templates.entries()) {
+    browser.menus.create({
+      id: `thunderplates-${index}`,
+      parentId,
+      title: t.name,
+      contexts: ['editable'],
+    });
+  }
+}
+
+browser.runtime.onInstalled.addListener(async () => {
   // Initialize storage with empty templates array if not present
-  browser.storage.local.get({ templates: [] }).then(() => {});
+  await browser.storage.local.get({ templates: [] });
+  createContextMenus();
+});
+
+browser.runtime.onStartup.addListener(createContextMenus);
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.templates) {
+    createContextMenus();
+  }
+});
+
+browser.menus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId.startsWith('thunderplates-')) {
+    const index = parseInt(info.menuItemId.split('-')[1], 10);
+    const { templates = [] } = await browser.storage.local.get('templates');
+    const template = templates[index];
+    if (template) {
+      await browser.compose.insertHTML(tab.id, template.body);
+    }
+  }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,8 @@
   "permissions": [
     "compose",
     "storage",
-    "tabs"
+    "tabs",
+    "menus"
   ],
   "background": {
     "scripts": ["background.js"]


### PR DESCRIPTION
## Summary
- add a context menu in compose windows with template options
- insert the selected template's body at the cursor position
- include `menus` permission in the manifest

## Testing
- `npx --yes web-ext lint > /tmp/web-ext-lint.log && tail -n 20 /tmp/web-ext-lint.log`

------
https://chatgpt.com/codex/tasks/task_e_685f1fd79420833182885bdb75795aba